### PR TITLE
Own the React↔MapLibre binding and add a neutral map port

### DIFF
--- a/src/components/Map.test.tsx
+++ b/src/components/Map.test.tsx
@@ -15,7 +15,7 @@ let currentMap: { flyTo: typeof flyTo; fitBounds: typeof fitBounds } | null = {
 const mapProps = jest.fn();
 const markerProps = jest.fn();
 
-jest.mock("react-map-gl/maplibre", () => {
+jest.mock("./map/adapters/maplibre", () => {
   return {
     __esModule: true,
     default: ({ children, ...props }: { children?: ReactNode }) => {

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -3,7 +3,7 @@ import React from "react";
 import styles from "./Map.module.css";
 import pinStyles from "./mapPin.module.css";
 
-import Map, { Marker, useMap } from "react-map-gl/maplibre";
+import Map, { Marker, useMap } from "./map/adapters/maplibre";
 import type { ProjectionSpecification } from "maplibre-gl";
 import { AppLink as Link } from "./platform";
 import { computeWrapAwareBounds } from "../util/mapBounds";

--- a/src/components/MapContextMenu.test.tsx
+++ b/src/components/MapContextMenu.test.tsx
@@ -7,7 +7,7 @@ import type { ReactNode } from "react";
 import { MapContextMenu } from "./MapContextMenu";
 
 const popupProps = jest.fn();
-jest.mock("react-map-gl/maplibre", () => ({
+jest.mock("./map/adapters/maplibre", () => ({
   Popup: ({ children, ...props }: { children?: ReactNode }) => {
     popupProps(props);
     return <div data-testid="popup">{children}</div>;

--- a/src/components/MapContextMenu.tsx
+++ b/src/components/MapContextMenu.tsx
@@ -1,4 +1,4 @@
-import { Popup } from "react-map-gl/maplibre";
+import { Popup } from "./map/adapters/maplibre";
 import { buildExternalMapLinks } from "./mapInteractions";
 import styles from "./MapWorld.module.css";
 

--- a/src/components/MapDirector.test.tsx
+++ b/src/components/MapDirector.test.tsx
@@ -10,7 +10,7 @@ const flyTo = jest.fn();
 const stop = jest.fn();
 let currentMap: { flyTo: typeof flyTo; stop: typeof stop } | null = { flyTo, stop };
 
-jest.mock("react-map-gl/maplibre", () => ({
+jest.mock("./map/adapters/maplibre", () => ({
   useMap: () => ({ current: currentMap }),
 }));
 

--- a/src/components/MapDirector.tsx
+++ b/src/components/MapDirector.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useMap } from "react-map-gl/maplibre";
+import { useMap } from "./map/adapters/maplibre";
 import type { MapWorldEntry } from "../util/pageDataTypes";
 
 const DIRECTOR_CADENCE_MS = 7_500;

--- a/src/components/MapPhotoMarkers.test.tsx
+++ b/src/components/MapPhotoMarkers.test.tsx
@@ -8,7 +8,7 @@ import type { PhotoWithStyle } from "./mapWorldViewModel";
 import { MapPhotoMarkers } from "./MapPhotoMarkers";
 
 const stopPropagation = jest.fn();
-jest.mock("react-map-gl/maplibre", () => ({
+jest.mock("./map/adapters/maplibre", () => ({
   Marker: ({
     children,
     onClick,

--- a/src/components/MapPhotoMarkers.tsx
+++ b/src/components/MapPhotoMarkers.tsx
@@ -1,4 +1,4 @@
-import { Marker } from "react-map-gl/maplibre";
+import { Marker } from "./map/adapters/maplibre";
 import type { PhotoWithStyle } from "./mapWorldViewModel";
 import { formatMapPhotoDate } from "./mapWorldViewModel";
 import {

--- a/src/components/MapPhotoPopup.test.tsx
+++ b/src/components/MapPhotoPopup.test.tsx
@@ -7,7 +7,7 @@ import type { ReactNode } from "react";
 import type { MapWorldEntry } from "../util/pageDataTypes";
 import { MapPhotoPopup } from "./MapPhotoPopup";
 
-jest.mock("react-map-gl/maplibre", () => ({
+jest.mock("./map/adapters/maplibre", () => ({
   Popup: ({ children }: { children?: ReactNode }) => <div data-testid="popup">{children}</div>,
 }));
 

--- a/src/components/MapPhotoPopup.tsx
+++ b/src/components/MapPhotoPopup.tsx
@@ -1,5 +1,5 @@
 import { AppLink as Link } from "./platform";
-import { Popup } from "react-map-gl/maplibre";
+import { Popup } from "./map/adapters/maplibre";
 import { exifWallClockTimestamp } from "../util/exifTime";
 import { getRelativeTimeString } from "../util/time";
 import type { MapWorldEntry } from "../util/pageDataTypes";

--- a/src/components/MapRouteOverlay.test.tsx
+++ b/src/components/MapRouteOverlay.test.tsx
@@ -13,7 +13,7 @@ import {
 import { MapRouteOverlay } from "./MapRouteOverlay";
 
 let currentMap: any = null;
-jest.mock("react-map-gl/maplibre", () => ({ useMap: () => ({ current: currentMap }) }));
+jest.mock("./map/adapters/maplibre", () => ({ useMap: () => ({ current: currentMap }) }));
 jest.mock("./mapRouteOverlayModel", () => ({
   ...jest.requireActual("./mapRouteOverlayModel"),
   projectRouteSegments: jest.fn(),

--- a/src/components/MapRouteOverlay.tsx
+++ b/src/components/MapRouteOverlay.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { useMap } from "react-map-gl/maplibre";
+import { useMap } from "./map/adapters/maplibre";
 import type { RouteMode, RoutePoint } from "./mapRoute";
 import {
   formatDistanceKm,

--- a/src/components/MapWorld.server.test.tsx
+++ b/src/components/MapWorld.server.test.tsx
@@ -5,7 +5,7 @@
 import { renderToString } from "react-dom/server";
 import type { ReactNode } from "react";
 
-jest.mock("react-map-gl/maplibre", () => ({
+jest.mock("./map/adapters/maplibre", () => ({
   __esModule: true,
   default: ({ children }: { children?: ReactNode }) => <div>{children}</div>,
   ScaleControl: () => null,

--- a/src/components/MapWorld.test.tsx
+++ b/src/components/MapWorld.test.tsx
@@ -57,7 +57,7 @@ const mapInstance = {
 };
 
 const mapRef = { current: mapInstance };
-jest.mock("react-map-gl/maplibre", () => {
+jest.mock("./map/adapters/maplibre", () => {
   return {
     __esModule: true,
     default: ({

--- a/src/components/MapWorld.tsx
+++ b/src/components/MapWorld.tsx
@@ -9,8 +9,8 @@ import MapLibreMap, {
   FullscreenControl,
   Layer,
   Source,
-  ViewStateChangeEvent,
-} from "react-map-gl/maplibre";
+  type ViewStateChangeEvent,
+} from "./map/adapters/maplibre";
 import { ThemeToggle } from "./ThemeToggle";
 import {
   buildContextRoutePoints,

--- a/src/components/MapWorldMapChildren.test.tsx
+++ b/src/components/MapWorldMapChildren.test.tsx
@@ -14,7 +14,7 @@ import {
 } from "./MapWorldMapChildren";
 
 let currentMap: any = null;
-jest.mock("react-map-gl/maplibre", () => ({ useMap: () => ({ current: currentMap }) }));
+jest.mock("./map/adapters/maplibre", () => ({ useMap: () => ({ current: currentMap }) }));
 
 const photo = (overrides: Partial<MapWorldEntry> = {}): MapWorldEntry => ({
   album: "test-simple",

--- a/src/components/MapWorldMapChildren.tsx
+++ b/src/components/MapWorldMapChildren.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { type MapRef, useMap } from "react-map-gl/maplibre";
+import { type MapRef, useMap } from "./map/adapters/maplibre";
 import { computeWrapAwareBounds } from "../util/mapBounds";
 import type { MapWorldEntry } from "../util/pageDataTypes";
 import type { MapBounds } from "./mapWorldViewModel";

--- a/src/components/StatsWorldMap.test.tsx
+++ b/src/components/StatsWorldMap.test.tsx
@@ -9,7 +9,7 @@ import { StatsWorldMap } from "./StatsWorldMap";
 const mapProps = jest.fn();
 const sourceProps = jest.fn();
 const layerProps = jest.fn();
-jest.mock("react-map-gl/maplibre", () => ({
+jest.mock("./map/adapters/maplibre", () => ({
   __esModule: true,
   default: ({ children, ...props }: { children?: ReactNode }) => {
     mapProps(props);

--- a/src/components/StatsWorldMap.tsx
+++ b/src/components/StatsWorldMap.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import Map, { Layer, Source } from "react-map-gl/maplibre";
+import Map, { Layer, Source } from "./map/adapters/maplibre";
 import styles from "./StatsWorldMap.module.css";
 import { MapLibreStyles } from "./MapLibreStyles";
 

--- a/src/components/guess/GuessMap.test.tsx
+++ b/src/components/guess/GuessMap.test.tsx
@@ -8,7 +8,7 @@ import { GuessMap } from "./GuessMap";
 const mockFitBounds = jest.fn();
 let mockCurrentMap: { fitBounds: typeof mockFitBounds } | null = { fitBounds: mockFitBounds };
 
-jest.mock("react-map-gl/maplibre", () => ({
+jest.mock("../map/adapters/maplibre", () => ({
   __esModule: true,
   default: ({
     children,

--- a/src/components/guess/GuessMap.tsx
+++ b/src/components/guess/GuessMap.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect } from "react";
-import Map, { Marker, Source, Layer, useMap } from "react-map-gl/maplibre";
+import Map, { Marker, Source, Layer, useMap } from "../map/adapters/maplibre";
 import type { MapLayerMouseEvent } from "maplibre-gl";
 // Imported directly rather than via the ambient `GeoJSON` namespace: the base
 // tsconfig pins `types`, so the global is not auto-included, and maplibre no

--- a/src/components/map/adapters/maplibre/Layer.tsx
+++ b/src/components/map/adapters/maplibre/Layer.tsx
@@ -1,0 +1,137 @@
+import React from "react";
+import type { AddLayerObject, FilterSpecification, LayerSpecification } from "./engine";
+import { SourceIdContext, useAttachedMap } from "./context";
+import { deepEqual, isStyleUsable, useGeneratedId, useStyleVersion } from "./internal";
+
+type OptionalId<T> = T extends { id: string } ? Omit<T, "id"> & { id?: string } : T;
+type OptionalSource<T> = T extends { source: string } ? Omit<T, "source"> & { source?: string } : T;
+
+export type LayerProps = OptionalSource<OptionalId<LayerSpecification>> & {
+  /** If set, the layer is inserted before the named layer. */
+  beforeId?: string;
+};
+
+/**
+ * The subset of a layer spec this adapter reads. Layer specs are a wide union,
+ * and consumers spread raw style-spec objects in, so they are read through one
+ * structural view rather than narrowed member by member.
+ */
+type LayerView = {
+  id?: string;
+  source?: string;
+  beforeId?: string;
+  paint?: Record<string, unknown>;
+  layout?: Record<string, unknown>;
+  filter?: FilterSpecification;
+  minzoom?: number;
+  maxzoom?: number;
+};
+
+const asLayerView = (props: LayerProps): LayerView => props as unknown as LayerView;
+
+const toAddLayerObject = (props: LayerProps, id: string, source: string | null): AddLayerObject => {
+  const spec: Record<string, unknown> = { id };
+  for (const [key, value] of Object.entries(props)) {
+    if (key !== "id" && key !== "beforeId") {
+      spec[key] = value;
+    }
+  }
+  if (spec.source === undefined && source !== null) {
+    spec.source = source;
+  }
+
+  return spec as unknown as AddLayerObject;
+};
+
+export const Layer = (props: LayerProps): null => {
+  const map = useAttachedMap();
+  const styleVersion = useStyleVersion(map);
+  const view = asLayerView(props);
+  const id = useGeneratedId("jsx-layer", view.id);
+  const sourceId = React.useContext(SourceIdContext);
+  const propsRef = React.useRef(props);
+  const previousViewRef = React.useRef(view);
+
+  // Adding is separate from removing: `styleVersion` re-adds a layer that a
+  // style reload dropped, but must never tear down a healthy one.
+  React.useEffect(() => {
+    if (!isStyleUsable(map) || map.getLayer(id)) {
+      return;
+    }
+
+    const current = propsRef.current;
+    const beforeId = asLayerView(current).beforeId;
+    map.addLayer(toAddLayerObject(current, id, sourceId), beforeId);
+    previousViewRef.current = asLayerView(current);
+  }, [map, id, sourceId, styleVersion]);
+
+  React.useEffect(() => {
+    if (!map) {
+      return;
+    }
+
+    return () => {
+      // The enclosing <Source> may already have swept this layer away.
+      if (isStyleUsable(map) && map.getLayer(id)) {
+        map.removeLayer(id);
+      }
+    };
+  }, [map, id]);
+
+  const { paint, layout, filter, minzoom, maxzoom, beforeId } = view;
+
+  React.useEffect(() => {
+    propsRef.current = props;
+
+    if (!isStyleUsable(map) || !map.getLayer(id)) {
+      return;
+    }
+
+    const previous = previousViewRef.current;
+
+    if (beforeId !== previous.beforeId) {
+      map.moveLayer(id, beforeId);
+    }
+
+    if (layout !== previous.layout) {
+      const previousLayout = previous.layout ?? {};
+      for (const [key, value] of Object.entries(layout ?? {})) {
+        if (!deepEqual(previousLayout[key], value)) {
+          map.setLayoutProperty(id, key, value);
+        }
+      }
+      for (const key of Object.keys(previousLayout)) {
+        if (!(layout && key in layout)) {
+          map.setLayoutProperty(id, key, undefined);
+        }
+      }
+    }
+
+    if (paint !== previous.paint) {
+      const previousPaint = previous.paint ?? {};
+      for (const [key, value] of Object.entries(paint ?? {})) {
+        if (!deepEqual(previousPaint[key], value)) {
+          map.setPaintProperty(id, key, value);
+        }
+      }
+      for (const key of Object.keys(previousPaint)) {
+        if (!(paint && key in paint)) {
+          map.setPaintProperty(id, key, undefined);
+        }
+      }
+    }
+
+    if (!deepEqual(filter, previous.filter)) {
+      map.setFilter(id, filter);
+    }
+
+    if (minzoom !== previous.minzoom || maxzoom !== previous.maxzoom) {
+      // Falls back to the style-spec defaults, which is what clearing a bound means.
+      map.setLayerZoomRange(id, minzoom ?? 0, maxzoom ?? 24);
+    }
+
+    previousViewRef.current = view;
+  });
+
+  return null;
+};

--- a/src/components/map/adapters/maplibre/MapView.tsx
+++ b/src/components/map/adapters/maplibre/MapView.tsx
@@ -1,0 +1,298 @@
+import React from "react";
+import { gl } from "./engine";
+import type {
+  AttributionControlOptions,
+  LngLatBoundsLike,
+  MapLibreEvent,
+  MapMouseEvent,
+  MapOptions,
+  MapWheelEvent,
+  ProjectionSpecification,
+  StyleSpecification,
+} from "./engine";
+import { MapContext, type MapContextValue } from "./context";
+import {
+  type MapRef,
+  toViewStateChangeEvent,
+  type ViewState,
+  type ViewStateChangeEvent,
+} from "./types";
+
+/** Matches MapLibre's own resize debounce, so resize behaviour is unchanged. */
+const RESIZE_DEBOUNCE_MS = 50;
+
+type CameraHandler = ((event: ViewStateChangeEvent) => void) | undefined;
+
+export type MapViewProps = {
+  /** A style-spec URL or an inline style document. */
+  mapStyle?: string | StyleSpecification;
+  /** Read once, at construction — the camera is uncontrolled after that. */
+  initialViewState?: Partial<ViewState>;
+  attributionControl?: false | AttributionControlOptions;
+  projection?: ProjectionSpecification | "mercator" | "globe";
+  /** CSS cursor applied to the map canvas. */
+  cursor?: string;
+  interactive?: boolean;
+  scrollZoom?: boolean;
+  dragPan?: boolean;
+  cooperativeGestures?: boolean;
+  minZoom?: number;
+  maxZoom?: number;
+  maxBounds?: LngLatBoundsLike;
+  renderWorldCopies?: boolean;
+  /** Container id, class and inline style. */
+  id?: string;
+  className?: string;
+  style?: React.CSSProperties;
+  children?: React.ReactNode;
+  onLoad?: (event: MapLibreEvent) => void;
+  onMoveStart?: (event: ViewStateChangeEvent) => void;
+  onMove?: (event: ViewStateChangeEvent) => void;
+  onMoveEnd?: (event: ViewStateChangeEvent) => void;
+  onZoomStart?: (event: ViewStateChangeEvent) => void;
+  onZoom?: (event: ViewStateChangeEvent) => void;
+  onZoomEnd?: (event: ViewStateChangeEvent) => void;
+  onDragStart?: (event: ViewStateChangeEvent) => void;
+  onDrag?: (event: ViewStateChangeEvent) => void;
+  onDragEnd?: (event: ViewStateChangeEvent) => void;
+  onWheel?: (event: MapWheelEvent) => void;
+  onClick?: (event: MapMouseEvent) => void;
+  onContextMenu?: (event: MapMouseEvent) => void;
+};
+
+const toProjectionSpec = (
+  projection: ProjectionSpecification | "mercator" | "globe",
+): ProjectionSpecification => (typeof projection === "string" ? { type: projection } : projection);
+
+const buildMapOptions = (container: HTMLElement, props: MapViewProps): MapOptions => {
+  const view = props.initialViewState ?? {};
+  const options: MapOptions = {
+    container,
+    center: [view.longitude ?? 0, view.latitude ?? 0],
+    zoom: view.zoom ?? 0,
+    bearing: view.bearing ?? 0,
+    pitch: view.pitch ?? 0,
+    // The adapter owns container resizing (see the ResizeObserver below), so a
+    // size change is applied once rather than once here and once by MapLibre.
+    trackResize: false,
+  };
+
+  // Optional options are omitted rather than set to `undefined`: MapLibre reads
+  // several of them with a presence check rather than a nullish check.
+  if (props.mapStyle !== undefined) {
+    options.style = props.mapStyle;
+  }
+  if (props.attributionControl !== undefined) {
+    options.attributionControl = props.attributionControl;
+  }
+  if (props.interactive !== undefined) {
+    options.interactive = props.interactive;
+  }
+  if (props.scrollZoom !== undefined) {
+    options.scrollZoom = props.scrollZoom;
+  }
+  if (props.dragPan !== undefined) {
+    options.dragPan = props.dragPan;
+  }
+  if (props.cooperativeGestures !== undefined) {
+    options.cooperativeGestures = props.cooperativeGestures;
+  }
+  if (props.minZoom !== undefined) {
+    options.minZoom = props.minZoom;
+  }
+  if (props.maxZoom !== undefined) {
+    options.maxZoom = props.maxZoom;
+  }
+  if (props.maxBounds !== undefined) {
+    options.maxBounds = props.maxBounds;
+  }
+  if (props.renderWorldCopies !== undefined) {
+    options.renderWorldCopies = props.renderWorldCopies;
+  }
+
+  return options;
+};
+
+const MapViewImpl = (
+  props: MapViewProps,
+  ref: React.ForwardedRef<MapRef | null>,
+): React.JSX.Element => {
+  const containerRef = React.useRef<HTMLDivElement | null>(null);
+  const mapRef = React.useRef<MapRef | null>(null);
+  // Listeners are registered once and read the latest props through this ref,
+  // so a re-render never has to tear listeners down and add them back.
+  const propsRef = React.useRef(props);
+  propsRef.current = props;
+  // Seeded with the style the map is constructed from, so the first pass of the
+  // style effect does not reload an identical style.
+  const appliedStyleRef = React.useRef(props.mapStyle);
+
+  const [readyMap, setReadyMap] = React.useState<MapRef | null>(null);
+
+  React.useEffect(() => {
+    // SSR guard: there is no DOM to render a WebGL map into.
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const container = containerRef.current;
+    // StrictMode double-mount guard: a second invocation must not build a
+    // second map into the same container.
+    if (!container || mapRef.current) {
+      return;
+    }
+
+    const map = new gl.Map(buildMapOptions(container, propsRef.current));
+    mapRef.current = map;
+
+    const emitCamera =
+      (type: ViewStateChangeEvent["type"], pick: (props: MapViewProps) => CameraHandler) =>
+      (event: MapLibreEvent<MouseEvent | TouchEvent | WheelEvent | undefined>) => {
+        pick(propsRef.current)?.(toViewStateChangeEvent(type, map, event.originalEvent));
+      };
+
+    const onLoad = (event: MapLibreEvent) => {
+      // Children mount only once the style is in place, so sources, layers,
+      // markers and popups never touch an unready map.
+      setReadyMap(map);
+      propsRef.current.onLoad?.(event);
+    };
+    const applyProjection = () => {
+      const projection = propsRef.current.projection;
+      if (projection === undefined) {
+        return;
+      }
+      const next = toProjectionSpec(projection);
+      // Setting the projection mutates the style, which fires `styledata`
+      // again — compare first so re-applying cannot loop.
+      if (JSON.stringify(map.getProjection()?.type) === JSON.stringify(next.type)) {
+        return;
+      }
+      map.setProjection(next);
+    };
+    const onMoveStart = emitCamera("movestart", (current) => current.onMoveStart);
+    const onMove = emitCamera("move", (current) => current.onMove);
+    const onMoveEnd = emitCamera("moveend", (current) => current.onMoveEnd);
+    const onZoomStart = emitCamera("zoomstart", (current) => current.onZoomStart);
+    const onZoom = emitCamera("zoom", (current) => current.onZoom);
+    const onZoomEnd = emitCamera("zoomend", (current) => current.onZoomEnd);
+    const onDragStart = emitCamera("dragstart", (current) => current.onDragStart);
+    const onDrag = emitCamera("drag", (current) => current.onDrag);
+    const onDragEnd = emitCamera("dragend", (current) => current.onDragEnd);
+    const onWheel = (event: MapWheelEvent) => {
+      propsRef.current.onWheel?.(event);
+    };
+    const onClick = (event: MapMouseEvent) => {
+      propsRef.current.onClick?.(event);
+    };
+    const onContextMenu = (event: MapMouseEvent) => {
+      propsRef.current.onContextMenu?.(event);
+    };
+
+    map.on("load", onLoad);
+    // A style swap wipes the projection, so re-apply it whenever the style settles.
+    map.on("styledata", applyProjection);
+    map.on("movestart", onMoveStart);
+    map.on("move", onMove);
+    map.on("moveend", onMoveEnd);
+    map.on("zoomstart", onZoomStart);
+    map.on("zoom", onZoom);
+    map.on("zoomend", onZoomEnd);
+    map.on("dragstart", onDragStart);
+    map.on("drag", onDrag);
+    map.on("dragend", onDragEnd);
+    map.on("wheel", onWheel);
+    map.on("click", onClick);
+    map.on("contextmenu", onContextMenu);
+
+    let resizeTimer: ReturnType<typeof setTimeout> | null = null;
+    let lastWidth = container.clientWidth;
+    let lastHeight = container.clientHeight;
+    const observer =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(() => {
+            if (resizeTimer) {
+              clearTimeout(resizeTimer);
+            }
+            resizeTimer = setTimeout(() => {
+              resizeTimer = null;
+              const width = container.clientWidth;
+              const height = container.clientHeight;
+              // Resizing fires `movestart`/`moveend`, so only resize when the
+              // container really did change size.
+              if (width === lastWidth && height === lastHeight) {
+                return;
+              }
+              lastWidth = width;
+              lastHeight = height;
+              map.resize();
+              map.redraw();
+            }, RESIZE_DEBOUNCE_MS);
+          });
+    observer?.observe(container);
+
+    return () => {
+      observer?.disconnect();
+      if (resizeTimer) {
+        clearTimeout(resizeTimer);
+      }
+      mapRef.current = null;
+      setReadyMap(null);
+      map.remove();
+    };
+  }, []);
+
+  React.useImperativeHandle<MapRef | null, MapRef | null>(ref, () => readyMap ?? mapRef.current, [
+    readyMap,
+  ]);
+
+  const { mapStyle, cursor } = props;
+
+  React.useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !readyMap || mapStyle === undefined || mapStyle === appliedStyleRef.current) {
+      return;
+    }
+    appliedStyleRef.current = mapStyle;
+    map.setStyle(mapStyle);
+  }, [mapStyle, readyMap]);
+
+  React.useEffect(() => {
+    const map = mapRef.current;
+    if (!map || !readyMap) {
+      return;
+    }
+    map.getCanvas().style.cursor = cursor ?? "";
+  }, [cursor, readyMap]);
+
+  const contextValue = React.useMemo<MapContextValue | null>(
+    () => (readyMap ? { map: readyMap } : null),
+    [readyMap],
+  );
+
+  const containerStyle = React.useMemo<React.CSSProperties>(
+    () => ({ position: "relative", width: "100%", height: "100%", ...props.style }),
+    [props.style],
+  );
+
+  return (
+    <div
+      {...(props.id !== undefined ? { id: props.id } : {})}
+      {...(props.className !== undefined ? { className: props.className } : {})}
+      ref={containerRef}
+      style={containerStyle}
+    >
+      {contextValue ? (
+        <MapContext.Provider value={contextValue}>
+          <div data-map-children="" style={{ height: "100%" }}>
+            {props.children}
+          </div>
+        </MapContext.Provider>
+      ) : null}
+    </div>
+  );
+};
+
+/** Drop-in replacement for `react-map-gl/maplibre`'s default `<Map>` export. */
+export const MapView = React.forwardRef(MapViewImpl);

--- a/src/components/map/adapters/maplibre/Marker.tsx
+++ b/src/components/map/adapters/maplibre/Marker.tsx
@@ -1,0 +1,103 @@
+import React from "react";
+import { createPortal } from "react-dom";
+import { gl } from "./engine";
+import type { GlMarker, MarkerOptions } from "./engine";
+import { useAttachedMap } from "./context";
+
+export type MarkerEvent<OriginalEventT = undefined> = {
+  type: string;
+  target: GlMarker;
+  originalEvent: OriginalEventT;
+};
+
+export type MarkerProps = MarkerOptions & {
+  /** Longitude of the anchor location. */
+  longitude: number;
+  /** Latitude of the anchor location. */
+  latitude: number;
+  /** CSS style override, applied to the marker element. */
+  style?: React.CSSProperties;
+  onClick?: (event: MarkerEvent<MouseEvent>) => void;
+  children?: React.ReactNode;
+};
+
+const hasRenderableChildren = (children: React.ReactNode): boolean => {
+  let found = false;
+  React.Children.forEach(children, (child) => {
+    if (child) {
+      found = true;
+    }
+  });
+
+  return found;
+};
+
+const applyStyle = (element: HTMLElement, style: React.CSSProperties | undefined) => {
+  if (!style) {
+    return;
+  }
+
+  Object.assign(element.style, style);
+};
+
+const MarkerImpl = (
+  props: MarkerProps,
+  ref: React.ForwardedRef<GlMarker | null>,
+): React.JSX.Element | null => {
+  const map = useAttachedMap();
+  const propsRef = React.useRef(props);
+  propsRef.current = props;
+
+  // Built once: the element is a stable portal target, and MarkerOptions other
+  // than the position are constant at every call site in this repo.
+  const marker = React.useMemo(() => {
+    const initial = propsRef.current;
+    const options: MarkerOptions = { ...initial };
+    if (hasRenderableChildren(initial.children)) {
+      options.element = document.createElement("div");
+    }
+
+    const instance = new gl.Marker(options);
+    instance.setLngLat([initial.longitude, initial.latitude]);
+    instance.getElement().addEventListener("click", (event: MouseEvent) => {
+      propsRef.current.onClick?.({ type: "click", target: instance, originalEvent: event });
+    });
+
+    return instance;
+  }, []);
+
+  React.useEffect(() => {
+    if (!map) {
+      return;
+    }
+
+    marker.addTo(map);
+
+    return () => {
+      marker.remove();
+    };
+  }, [map, marker]);
+
+  const { longitude, latitude, style } = props;
+
+  React.useEffect(() => {
+    const position = marker.getLngLat();
+    if (position.lng !== longitude || position.lat !== latitude) {
+      marker.setLngLat([longitude, latitude]);
+    }
+  }, [marker, longitude, latitude]);
+
+  React.useEffect(() => {
+    applyStyle(marker.getElement(), style);
+  }, [marker, style]);
+
+  React.useImperativeHandle(ref, () => marker, [marker]);
+
+  if (!map) {
+    return null;
+  }
+
+  return createPortal(props.children, marker.getElement());
+};
+
+export const Marker = React.memo(React.forwardRef(MarkerImpl));

--- a/src/components/map/adapters/maplibre/Popup.tsx
+++ b/src/components/map/adapters/maplibre/Popup.tsx
@@ -1,0 +1,111 @@
+import React from "react";
+import { createPortal } from "react-dom";
+import { gl } from "./engine";
+import type { GlPopup, PopupOptions } from "./engine";
+import { useAttachedMap } from "./context";
+import { deepEqual } from "./internal";
+
+export type PopupEvent = {
+  type: "open" | "close";
+  target: GlPopup;
+};
+
+export type PopupProps = PopupOptions & {
+  /** Longitude of the anchor location. */
+  longitude: number;
+  /** Latitude of the anchor location. */
+  latitude: number;
+  onOpen?: (event: PopupEvent) => void;
+  onClose?: (event: PopupEvent) => void;
+  children?: React.ReactNode;
+};
+
+const PopupImpl = (
+  props: PopupProps,
+  ref: React.ForwardedRef<GlPopup | null>,
+): React.JSX.Element | null => {
+  const map = useAttachedMap();
+  const propsRef = React.useRef(props);
+  const previousPropsRef = React.useRef(props);
+  propsRef.current = props;
+
+  // A stable container the popup renders through, so React owns the content and
+  // MapLibre owns the positioning.
+  const container = React.useMemo(() => document.createElement("div"), []);
+  const popup = React.useMemo(() => {
+    const initial = propsRef.current;
+    const instance = new gl.Popup({ ...initial });
+    instance.setLngLat([initial.longitude, initial.latitude]);
+
+    return instance;
+  }, []);
+
+  React.useEffect(() => {
+    if (!map) {
+      return;
+    }
+
+    const onOpen = () => {
+      propsRef.current.onOpen?.({ type: "open", target: popup });
+    };
+    const onClose = () => {
+      propsRef.current.onClose?.({ type: "close", target: popup });
+    };
+
+    popup.on("open", onOpen);
+    popup.on("close", onClose);
+    popup.setDOMContent(container).addTo(map);
+
+    return () => {
+      // Unmounting is not a user-driven close, so the callback is detached
+      // before removal — otherwise a StrictMode remount reports a false close.
+      popup.off("open", onOpen);
+      popup.off("close", onClose);
+      if (popup.isOpen()) {
+        popup.remove();
+      }
+    };
+  }, [map, popup, container]);
+
+  React.useImperativeHandle(ref, () => popup, [popup]);
+
+  const { longitude, latitude, offset, maxWidth, className } = props;
+
+  // `anchor` is a construction-time option here — no call site changes it after
+  // mount, and MapLibre only reads it while placing an open popup.
+  React.useEffect(() => {
+    if (!popup.isOpen()) {
+      return;
+    }
+
+    const previous = previousPropsRef.current;
+    const position = popup.getLngLat();
+    if (position.lng !== longitude || position.lat !== latitude) {
+      popup.setLngLat([longitude, latitude]);
+    }
+    if (offset !== undefined && !deepEqual(previous.offset, offset)) {
+      popup.setOffset(offset);
+    }
+    if (maxWidth !== undefined && previous.maxWidth !== maxWidth) {
+      popup.setMaxWidth(maxWidth);
+    }
+    if (previous.className !== className) {
+      for (const name of (previous.className ?? "").split(" ").filter(Boolean)) {
+        popup.removeClassName(name);
+      }
+      for (const name of (className ?? "").split(" ").filter(Boolean)) {
+        popup.addClassName(name);
+      }
+    }
+
+    previousPropsRef.current = propsRef.current;
+  }, [popup, longitude, latitude, offset, maxWidth, className]);
+
+  if (!map) {
+    return null;
+  }
+
+  return createPortal(props.children, container);
+};
+
+export const Popup = React.memo(React.forwardRef(PopupImpl));

--- a/src/components/map/adapters/maplibre/Source.tsx
+++ b/src/components/map/adapters/maplibre/Source.tsx
@@ -1,0 +1,87 @@
+import React from "react";
+import { gl } from "./engine";
+import type { SourceSpecification } from "./engine";
+import { SourceIdContext, useAttachedMap } from "./context";
+import { isStyleUsable, useGeneratedId, useStyleVersion } from "./internal";
+
+export type SourceProps = SourceSpecification & {
+  id?: string;
+  children?: React.ReactNode;
+};
+
+/** Everything except the props this adapter adds is the style-spec source. */
+const toSourceSpec = (props: SourceProps): SourceSpecification => {
+  const spec: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(props)) {
+    if (key !== "id" && key !== "children") {
+      spec[key] = value;
+    }
+  }
+
+  return spec as unknown as SourceSpecification;
+};
+
+export const Source = (props: SourceProps): React.JSX.Element | null => {
+  const map = useAttachedMap();
+  const styleVersion = useStyleVersion(map);
+  const id = useGeneratedId("jsx-source", props.id);
+  const propsRef = React.useRef(props);
+  propsRef.current = props;
+  const [attached, setAttached] = React.useState(false);
+
+  // Adding is separate from removing: `styleVersion` re-adds a source that a
+  // style reload dropped, but must never tear down a healthy one.
+  React.useEffect(() => {
+    if (!isStyleUsable(map)) {
+      return;
+    }
+
+    if (!map.getSource(id)) {
+      map.addSource(id, toSourceSpec(propsRef.current));
+    }
+    setAttached(true);
+  }, [map, id, styleVersion]);
+
+  React.useEffect(() => {
+    if (!map) {
+      return;
+    }
+
+    return () => {
+      setAttached(false);
+      if (!isStyleUsable(map) || !map.getSource(id)) {
+        return;
+      }
+
+      // React destroys this effect before the child layers', so the layers
+      // still using the source have to go first.
+      for (const layer of map.getStyle().layers) {
+        if ("source" in layer && layer.source === id) {
+          map.removeLayer(layer.id);
+        }
+      }
+      map.removeSource(id);
+    };
+  }, [map, id]);
+
+  const data = props.type === "geojson" ? props.data : null;
+
+  React.useEffect(() => {
+    if (!attached || !isStyleUsable(map) || data === null) {
+      return;
+    }
+
+    const source = map.getSource(id);
+    if (source instanceof gl.GeoJSONSource) {
+      source.setData(data);
+    }
+  }, [attached, map, id, data]);
+
+  // Layers are mounted only once the source exists, so their own effects — which
+  // React runs after this one — can always find it.
+  if (!attached) {
+    return null;
+  }
+
+  return <SourceIdContext.Provider value={id}>{props.children}</SourceIdContext.Provider>;
+};

--- a/src/components/map/adapters/maplibre/context.ts
+++ b/src/components/map/adapters/maplibre/context.ts
@@ -1,0 +1,20 @@
+import React from "react";
+import type { MapRef } from "./types";
+
+export type MapContextValue = {
+  map: MapRef;
+};
+
+export const MapContext = React.createContext<MapContextValue | null>(null);
+
+/**
+ * The source a `<Layer>` belongs to, supplied by the enclosing `<Source>` so
+ * layers do not have to name it. A layer may still set `source` explicitly.
+ */
+export const SourceIdContext = React.createContext<string | null>(null);
+
+/** Internal accessor — returns null outside a map, so children stay harmless. */
+export const useMapContext = (): MapContextValue | null => React.useContext(MapContext);
+
+/** The map a child is attached to, or null while there is none. */
+export const useAttachedMap = (): MapRef | null => useMapContext()?.map ?? null;

--- a/src/components/map/adapters/maplibre/controls.tsx
+++ b/src/components/map/adapters/maplibre/controls.tsx
@@ -1,0 +1,65 @@
+import React from "react";
+import { gl } from "./engine";
+import type {
+  AttributionControlOptions,
+  ControlPosition,
+  FullscreenControlOptions,
+  GeolocateControlOptions,
+  IControl,
+  NavigationControlOptions,
+  ScaleControlOptions,
+} from "./engine";
+import { useAttachedMap } from "./context";
+
+type ControlPlacement = { position?: ControlPosition };
+
+const useMapControl = (create: () => IControl, position: ControlPosition | undefined): null => {
+  const map = useAttachedMap();
+  const createRef = React.useRef(create);
+  createRef.current = create;
+
+  React.useEffect(() => {
+    if (!map) {
+      return;
+    }
+
+    const control = createRef.current();
+    if (!map.hasControl(control)) {
+      map.addControl(control, position);
+    }
+
+    return () => {
+      // The map may already be gone: React destroys parent effects first.
+      if (map.hasControl(control)) {
+        map.removeControl(control);
+      }
+    };
+  }, [map, position]);
+
+  return null;
+};
+
+export type NavigationControlProps = NavigationControlOptions & ControlPlacement;
+
+export const NavigationControl = (props: NavigationControlProps): null =>
+  useMapControl(() => new gl.NavigationControl(props), props.position);
+
+export type GeolocateControlProps = GeolocateControlOptions & ControlPlacement;
+
+export const GeolocateControl = (props: GeolocateControlProps): null =>
+  useMapControl(() => new gl.GeolocateControl(props), props.position);
+
+export type ScaleControlProps = ScaleControlOptions & ControlPlacement;
+
+export const ScaleControl = (props: ScaleControlProps): null =>
+  useMapControl(() => new gl.ScaleControl(props), props.position);
+
+export type FullscreenControlProps = FullscreenControlOptions & ControlPlacement;
+
+export const FullscreenControl = (props: FullscreenControlProps): null =>
+  useMapControl(() => new gl.FullscreenControl(props), props.position);
+
+export type AttributionControlProps = AttributionControlOptions & ControlPlacement;
+
+export const AttributionControl = (props: AttributionControlProps): null =>
+  useMapControl(() => new gl.AttributionControl(props), props.position);

--- a/src/components/map/adapters/maplibre/engine.ts
+++ b/src/components/map/adapters/maplibre/engine.ts
@@ -1,0 +1,39 @@
+/**
+ * Seam 1 — the single module in the application that imports the GL library.
+ *
+ * `maplibre-gl` and `mapbox-gl` share an API family, so swapping engines is a
+ * one-file change. No other adapter file may import the GL library directly.
+ */
+export * as gl from "maplibre-gl";
+
+export type {
+  AddLayerObject,
+  AttributionControlOptions,
+  ControlPosition,
+  FilterSpecification,
+  FullscreenControlOptions,
+  GeoJSONSourceSpecification,
+  GeolocateControlOptions,
+  IControl,
+  LayerSpecification,
+  LngLat,
+  LngLatBoundsLike,
+  Map as GlMap,
+  MapLayerMouseEvent,
+  MapLibreEvent,
+  MapMouseEvent,
+  MapOptions,
+  MapWheelEvent,
+  Marker as GlMarker,
+  MarkerOptions,
+  NavigationControlOptions,
+  Offset,
+  PaddingOptions,
+  Popup as GlPopup,
+  PopupOptions,
+  PositionAnchor,
+  ProjectionSpecification,
+  ScaleControlOptions,
+  SourceSpecification,
+  StyleSpecification,
+} from "maplibre-gl";

--- a/src/components/map/adapters/maplibre/index.ts
+++ b/src/components/map/adapters/maplibre/index.ts
@@ -1,0 +1,32 @@
+/**
+ * A drop-in replacement for the `react-map-gl/maplibre` surface this repo uses.
+ * Names match the ones `react-map-gl` exported, so consumers change only their
+ * import path.
+ *
+ * The GL library is reached exclusively through `./engine` (seam 1).
+ */
+export { MapView as default, type MapViewProps as MapProps } from "./MapView";
+export { Marker, type MarkerEvent, type MarkerProps } from "./Marker";
+export { Popup, type PopupEvent, type PopupProps } from "./Popup";
+export { Source, type SourceProps } from "./Source";
+export { Layer, type LayerProps } from "./Layer";
+export { useMap, type MapCollection } from "./useMapInstance";
+export {
+  AttributionControl,
+  type AttributionControlProps,
+  FullscreenControl,
+  type FullscreenControlProps,
+  GeolocateControl,
+  type GeolocateControlProps,
+  NavigationControl,
+  type NavigationControlProps,
+  ScaleControl,
+  type ScaleControlProps,
+} from "./controls";
+export type { MapRef, ViewState, ViewStateChangeEvent } from "./types";
+export type {
+  MapLayerMouseEvent,
+  MapLibreEvent as MapEvent,
+  MapMouseEvent,
+  MapWheelEvent,
+} from "./engine";

--- a/src/components/map/adapters/maplibre/internal.ts
+++ b/src/components/map/adapters/maplibre/internal.ts
@@ -1,0 +1,80 @@
+import React from "react";
+import type { MapRef } from "./types";
+
+/**
+ * Whether the map can still take style mutations. React destroys a parent's
+ * effects before its children's, so a `<Source>` or `<Layer>` cleanup can run
+ * after `<MapView>` has already removed the map.
+ */
+export const isStyleUsable = (map: MapRef | null): map is MapRef => {
+  if (!map || map._removed) {
+    return false;
+  }
+
+  return Boolean(map.style?._loaded);
+};
+
+/**
+ * A counter bumped on every `styledata` event, used to re-add sources and
+ * layers that a style reload wiped. Deliberately local to each component rather
+ * than shared through the map context: MapLibre fires `styledata` on any style
+ * mutation, and a shared version would re-render every marker on the map.
+ */
+export const useStyleVersion = (map: MapRef | null): number => {
+  const [version, setVersion] = React.useState(0);
+
+  React.useEffect(() => {
+    if (!map) {
+      return;
+    }
+
+    const onStyleData = () => {
+      setVersion((current) => current + 1);
+    };
+
+    map.on("styledata", onStyleData);
+
+    return () => {
+      map.off("styledata", onStyleData);
+    };
+  }, [map]);
+
+  return version;
+};
+
+/** Structural comparison for style-spec values (expressions are plain arrays). */
+export const deepEqual = (a: unknown, b: unknown): boolean => {
+  if (a === b) {
+    return true;
+  }
+
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((item, index) => deepEqual(item, b[index]));
+  }
+
+  if (typeof a === "object" && typeof b === "object" && a !== null && b !== null) {
+    const left = a as Record<string, unknown>;
+    const right = b as Record<string, unknown>;
+    const leftKeys = Object.keys(left);
+
+    return (
+      leftKeys.length === Object.keys(right).length &&
+      leftKeys.every((key) => deepEqual(left[key], right[key]))
+    );
+  }
+
+  return false;
+};
+
+let idCounter = 0;
+
+/** The caller's id, or a stable generated one for anonymous sources and layers. */
+export const useGeneratedId = (prefix: string, id: string | undefined): string => {
+  const generated = React.useRef<string | null>(null);
+  if (generated.current === null) {
+    idCounter += 1;
+    generated.current = `${prefix}-${idCounter}`;
+  }
+
+  return id ?? generated.current;
+};

--- a/src/components/map/adapters/maplibre/types.ts
+++ b/src/components/map/adapters/maplibre/types.ts
@@ -1,0 +1,69 @@
+import type { GlMap, PaddingOptions } from "./engine";
+
+/**
+ * The handle consumers hold onto. Every map method this repo calls — `project`,
+ * `unproject`, `flyTo`, `fitBounds`, `getBounds`, `getCenter`, `getZoom`,
+ * `getContainer`, `getCanvas`, `on`/`off` — is native to the GL map, so there
+ * is nothing to wrap.
+ */
+export type MapRef = GlMap;
+
+/** The camera state, in the shape the existing callbacks already read. */
+export type ViewState = {
+  /** Longitude at the map centre. */
+  longitude: number;
+  /** Latitude at the map centre. */
+  latitude: number;
+  zoom: number;
+  /** Rotation in degrees, anticlockwise from north. */
+  bearing: number;
+  /** Angle in degrees at which the camera looks at the ground. */
+  pitch: number;
+  /** Pixels reserved on each side of the viewport, shifting the vanishing point. */
+  padding: PaddingOptions;
+};
+
+/** The camera events that carry a derived `viewState`. */
+export type ViewStateChangeEventType =
+  | "movestart"
+  | "move"
+  | "moveend"
+  | "zoomstart"
+  | "zoom"
+  | "zoomend"
+  | "dragstart"
+  | "drag"
+  | "dragend";
+
+export type ViewStateChangeEvent = {
+  type: ViewStateChangeEventType;
+  target: MapRef;
+  /** The DOM event behind the camera change, when the change came from input. */
+  originalEvent: MouseEvent | TouchEvent | WheelEvent | undefined;
+  viewState: ViewState;
+};
+
+/** Reads the live camera off the map — the map is the single source of truth. */
+export const toViewState = (map: MapRef): ViewState => {
+  const centre = map.getCenter();
+
+  return {
+    longitude: centre.lng,
+    latitude: centre.lat,
+    zoom: map.getZoom(),
+    bearing: map.getBearing(),
+    pitch: map.getPitch(),
+    padding: map.getPadding(),
+  };
+};
+
+export const toViewStateChangeEvent = (
+  type: ViewStateChangeEventType,
+  map: MapRef,
+  originalEvent: MouseEvent | TouchEvent | WheelEvent | undefined,
+): ViewStateChangeEvent => ({
+  type,
+  target: map,
+  originalEvent,
+  viewState: toViewState(map),
+});

--- a/src/components/map/adapters/maplibre/useMapInstance.ts
+++ b/src/components/map/adapters/maplibre/useMapInstance.ts
@@ -1,0 +1,19 @@
+import React from "react";
+import { useMapContext } from "./context";
+import type { MapRef } from "./types";
+
+/**
+ * Matches the call sites we already have: `const { current: map } = useMap()`.
+ * `current` is `undefined` until the map has finished loading, and outside a
+ * `<MapView>` entirely, so every consumer already guards on it.
+ */
+export type MapCollection = {
+  current: MapRef | undefined;
+};
+
+export const useMap = (): MapCollection => {
+  const context = useMapContext();
+  const map = context?.map;
+
+  return React.useMemo(() => ({ current: map }), [map]);
+};

--- a/src/components/map/index.ts
+++ b/src/components/map/index.ts
@@ -1,0 +1,37 @@
+/**
+ * The map module's public face: the neutral React API plus the port vocabulary.
+ * Application components import from here and never reach into `./adapters/`.
+ */
+export {
+  DataLayer,
+  type DataLayerProps,
+  MapView,
+  type MapViewProps,
+  Marker,
+  type MarkerProps,
+  Popup,
+  type PopupProps,
+  useMap,
+} from "./react";
+export type {
+  Bounds,
+  CameraView,
+  FitBoundsOptions,
+  FlyToOptions,
+  LineFeature,
+  LngLat,
+  MapCamera,
+  MapCameraEvent,
+  MapCameraEventName,
+  MapEvent,
+  MapEventMap,
+  MapEventName,
+  MapInstance,
+  MapPointerEvent,
+  MapPointerEventName,
+  MapProjection,
+  MapWheelEvent,
+  MarkerAnchor,
+  PointFeature,
+  ScreenPoint,
+} from "./port";

--- a/src/components/map/port.ts
+++ b/src/components/map/port.ts
@@ -1,0 +1,143 @@
+/**
+ * Seam 2 — the provider-neutral map port.
+ *
+ * Nothing in this file may reference an implementation: no `maplibre-gl`, no GL
+ * style-spec, no React. It is the vocabulary application components speak, and
+ * the contract any adapter has to satisfy. The MapLibre binding lives in
+ * `./react.tsx` over `./adapters/maplibre/`.
+ */
+
+/** A geographic position, in degrees. */
+export type LngLat = { lng: number; lat: number };
+
+/** A geographic box as `[south-west, north-east]`. */
+export type Bounds = [LngLat, LngLat];
+
+/** A position in map-container pixels, origin at the container's top-left. */
+export type ScreenPoint = { x: number; y: number };
+
+/** A camera snapshot: where the map is looking, and how closely. */
+export type CameraView = { center: LngLat; zoom: number };
+
+export type FlyToOptions = {
+  center: LngLat;
+  zoom?: number;
+  /** Animation speed multiplier; 1 is the provider's default pace. */
+  speed?: number;
+};
+
+export type FitBoundsOptions = {
+  /** Pixels of breathing room kept on every side. */
+  padding?: number;
+  maxZoom?: number;
+  /** `false` jumps straight to the destination. */
+  animate?: boolean;
+};
+
+/** Reading and moving the camera. */
+export interface MapCamera {
+  getCenter(): LngLat;
+  getZoom(): number;
+  getBounds(): Bounds;
+  flyTo(options: FlyToOptions): void;
+  fitBounds(bounds: Bounds, options?: FitBoundsOptions): void;
+}
+
+/** Converting between geographic and screen coordinates. */
+export interface MapProjection {
+  project(at: LngLat): ScreenPoint;
+  unproject(at: ScreenPoint): LngLat;
+}
+
+/** Events that only report where the camera ended up. */
+export type MapCameraEventName = "load" | "move" | "moveend" | "zoom" | "zoomend" | "dragstart";
+
+/** Events raised by a pointer over the map surface. */
+export type MapPointerEventName = "click" | "contextmenu";
+
+export type MapCameraEvent = {
+  type: MapCameraEventName;
+  view: CameraView;
+};
+
+export type MapPointerEvent = {
+  type: MapPointerEventName;
+  /** Where the pointer was, on the ground. */
+  at: LngLat;
+  /** Where the pointer was, in container pixels. */
+  point: ScreenPoint;
+  originalEvent: MouseEvent;
+};
+
+export type MapWheelEvent = {
+  type: "wheel";
+  originalEvent: WheelEvent;
+};
+
+/** The payload each subscribable event carries. */
+export type MapEventMap = {
+  load: MapCameraEvent;
+  move: MapCameraEvent;
+  moveend: MapCameraEvent;
+  zoom: MapCameraEvent;
+  zoomend: MapCameraEvent;
+  dragstart: MapCameraEvent;
+  click: MapPointerEvent;
+  contextmenu: MapPointerEvent;
+  wheel: MapWheelEvent;
+};
+
+export type MapEventName = keyof MapEventMap;
+
+export type MapEvent = MapEventMap[MapEventName];
+
+/** The live map handle. Held only while the map is mounted and loaded. */
+export interface MapInstance extends MapCamera, MapProjection {
+  /**
+   * Subscribes to a map event. Returns an unsubscribe function — callers never
+   * have to hold on to the listener to detach it.
+   *
+   * Narrowed by event name, so `on("moveend", …)` sees a camera event and
+   * `on("click", …)` sees a pointer one; `on(name: MapEventName, …)` still
+   * type-checks with a listener taking the full `MapEvent` union.
+   */
+  on<Name extends MapEventName>(
+    event: Name,
+    listener: (event: MapEventMap[Name]) => void,
+  ): () => void;
+  getContainer(): HTMLElement;
+}
+
+/** Where a marker's element sits relative to its position. */
+export type MarkerAnchor =
+  | "center"
+  | "top"
+  | "bottom"
+  | "left"
+  | "right"
+  | "top-left"
+  | "top-right"
+  | "bottom-left"
+  | "bottom-right";
+
+/**
+ * Neutral data descriptions — deliberately not GL style-spec. Bulk data is
+ * described as features with their own colour and size, and the adapter decides
+ * how to draw them (for MapLibre, one GPU layer rather than one node each).
+ */
+export type PointFeature = {
+  id: string;
+  at: LngLat;
+  /** Any CSS colour the provider understands. Falls back to the port default. */
+  color?: string;
+  /** Radius in pixels. Falls back to the port default. */
+  radius?: number;
+};
+
+export type LineFeature = {
+  id: string;
+  path: LngLat[];
+  color: string;
+  /** Stroke width in pixels. */
+  width: number;
+};

--- a/src/components/map/react.test.tsx
+++ b/src/components/map/react.test.tsx
@@ -1,0 +1,433 @@
+/**
+ * @jest-environment jsdom
+ */
+
+import { act, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { DataLayer, MapView, useMap } from "./index";
+import type { MapInstance } from "./port";
+
+const mapProps = jest.fn();
+const sourceProps = jest.fn();
+const layerProps = jest.fn();
+const markerProps = jest.fn();
+const popupProps = jest.fn();
+
+// jsdom has no WebGL, so the adapter is replaced wholesale — the same pattern
+// the existing map component tests use. What is under test here is the
+// translation between the neutral port and the adapter's surface.
+let currentEngineMap: unknown = null;
+jest.mock("./adapters/maplibre", () => ({
+  __esModule: true,
+  default: ({ children, ...props }: { children?: ReactNode }) => {
+    mapProps(props);
+    return <div data-testid="map">{children}</div>;
+  },
+  Source: ({ children, ...props }: { children?: ReactNode }) => {
+    sourceProps(props);
+    return <div data-testid="source">{children}</div>;
+  },
+  Layer: (props: { id: string }) => {
+    layerProps(props);
+    return <div data-testid="layer">{props.id}</div>;
+  },
+  Marker: ({ children, ...props }: { children?: ReactNode }) => {
+    markerProps(props);
+    return <div data-testid="marker">{children}</div>;
+  },
+  Popup: ({ children, ...props }: { children?: ReactNode }) => {
+    popupProps(props);
+    return <div data-testid="popup">{children}</div>;
+  },
+  useMap: () => ({ current: currentEngineMap }),
+}));
+
+type EngineListener = (event: unknown) => void;
+
+const engineListeners = new Map<string, Set<EngineListener>>();
+const container = document.createElement("div");
+
+const engine = {
+  getCenter: jest.fn(() => ({ lng: 10, lat: 20 })),
+  getZoom: jest.fn(() => 4),
+  getBounds: jest.fn(() => ({
+    getWest: () => -1,
+    getSouth: () => -2,
+    getEast: () => 3,
+    getNorth: () => 4,
+  })),
+  flyTo: jest.fn(),
+  fitBounds: jest.fn(),
+  project: jest.fn(() => ({ x: 12, y: 34 })),
+  unproject: jest.fn(() => ({ lng: 5, lat: 6 })),
+  getContainer: jest.fn(() => container),
+  on: jest.fn((type: string, listener: EngineListener) => {
+    const registered = engineListeners.get(type) ?? new Set<EngineListener>();
+    registered.add(listener);
+    engineListeners.set(type, registered);
+  }),
+  off: jest.fn((type: string, listener: EngineListener) => {
+    engineListeners.get(type)?.delete(listener);
+  }),
+};
+
+const fireEngineEvent = (type: string, event?: unknown) => {
+  // Copied first, so a listener that unsubscribes itself cannot disturb the walk.
+  for (const listener of new Set(engineListeners.get(type) ?? [])) {
+    listener(event);
+  }
+};
+
+/** The props the mocked adapter map was last rendered with. */
+const lastMapProps = () => mapProps.mock.calls.at(-1)?.[0];
+
+/** Renders a map and hands back the neutral instance its `onLoad` published. */
+const renderLoadedMap = (children?: ReactNode): MapInstance => {
+  let instance: MapInstance | undefined;
+  render(
+    <MapView
+      styleUrl="https://tiles.example/style.json"
+      initialView={{ center: { lng: 103, lat: 1.25 }, zoom: 6 }}
+      onLoad={(map) => {
+        instance = map;
+      }}
+    >
+      {children}
+    </MapView>,
+  );
+  act(() => {
+    lastMapProps().onLoad({ type: "load", target: engine });
+  });
+  if (!instance) {
+    throw new Error("the map never published an instance");
+  }
+
+  return instance;
+};
+
+beforeEach(() => {
+  mapProps.mockClear();
+  sourceProps.mockClear();
+  layerProps.mockClear();
+  markerProps.mockClear();
+  popupProps.mockClear();
+  engine.flyTo.mockClear();
+  engine.fitBounds.mockClear();
+  engine.project.mockClear();
+  engine.unproject.mockClear();
+  engine.on.mockClear();
+  engine.off.mockClear();
+  engineListeners.clear();
+  currentEngineMap = null;
+});
+
+// The contract every adapter has to satisfy, exercised only through the port.
+describe("MapInstance contract", () => {
+  it("reads the camera in neutral shapes", () => {
+    const map = renderLoadedMap();
+
+    expect(map.getCenter()).toEqual({ lng: 10, lat: 20 });
+    expect(map.getZoom()).toBe(4);
+    expect(map.getBounds()).toEqual([
+      { lng: -1, lat: -2 },
+      { lng: 3, lat: 4 },
+    ]);
+    expect(map.getContainer()).toBe(container);
+  });
+
+  it("moves the camera, omitting options the caller left out", () => {
+    const map = renderLoadedMap();
+
+    map.flyTo({ center: { lng: 50, lat: 5 }, zoom: 10.5, speed: 2.2 });
+    expect(engine.flyTo).toHaveBeenCalledWith({ center: [50, 5], zoom: 10.5, speed: 2.2 });
+
+    map.flyTo({ center: { lng: 1, lat: 2 } });
+    expect(engine.flyTo).toHaveBeenLastCalledWith({ center: [1, 2] });
+
+    map.fitBounds(
+      [
+        { lng: 179, lat: 1 },
+        { lng: -179, lat: 2 },
+      ],
+      { padding: 36, maxZoom: 11, animate: false },
+    );
+    expect(engine.fitBounds).toHaveBeenCalledWith(
+      [
+        [179, 1],
+        [-179, 2],
+      ],
+      { padding: 36, maxZoom: 11, animate: false },
+    );
+
+    map.fitBounds([
+      { lng: 0, lat: 0 },
+      { lng: 1, lat: 1 },
+    ]);
+    expect(engine.fitBounds).toHaveBeenLastCalledWith(
+      [
+        [0, 0],
+        [1, 1],
+      ],
+      {},
+    );
+  });
+
+  it("round-trips projection between geography and screen pixels", () => {
+    const map = renderLoadedMap();
+
+    expect(map.project({ lng: 103, lat: 1.25 })).toEqual({ x: 12, y: 34 });
+    expect(engine.project).toHaveBeenCalledWith([103, 1.25]);
+    expect(map.unproject({ x: 12, y: 34 })).toEqual({ lng: 5, lat: 6 });
+    expect(engine.unproject).toHaveBeenCalledWith([12, 34]);
+  });
+
+  it("subscribes to camera events and detaches through the returned disposer", () => {
+    const map = renderLoadedMap();
+    const onMoveEnd = jest.fn();
+
+    const unsubscribe = map.on("moveend", onMoveEnd);
+    fireEngineEvent("moveend");
+    expect(onMoveEnd).toHaveBeenCalledWith({
+      type: "moveend",
+      view: { center: { lng: 10, lat: 20 }, zoom: 4 },
+    });
+
+    unsubscribe();
+    fireEngineEvent("moveend");
+    expect(onMoveEnd).toHaveBeenCalledTimes(1);
+    expect(engine.off).toHaveBeenCalledWith("moveend", expect.any(Function));
+  });
+
+  it("translates pointer and wheel events into neutral payloads", () => {
+    const map = renderLoadedMap();
+    const onClick = jest.fn();
+    const onWheel = jest.fn();
+    const click = new MouseEvent("click");
+    const wheel = new WheelEvent("wheel");
+
+    map.on("click", onClick);
+    map.on("wheel", onWheel);
+    fireEngineEvent("click", {
+      lngLat: { lng: 103, lat: 1.25 },
+      point: { x: 7, y: 8 },
+      originalEvent: click,
+    });
+    fireEngineEvent("wheel", { originalEvent: wheel });
+
+    expect(onClick).toHaveBeenCalledWith({
+      type: "click",
+      at: { lng: 103, lat: 1.25 },
+      point: { x: 7, y: 8 },
+      originalEvent: click,
+    });
+    expect(onWheel).toHaveBeenCalledWith({ type: "wheel", originalEvent: wheel });
+  });
+});
+
+describe("MapView", () => {
+  it("passes the style and initial camera to the adapter", () => {
+    renderLoadedMap();
+
+    expect(mapProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        mapStyle: "https://tiles.example/style.json",
+        initialViewState: { longitude: 103, latitude: 1.25, zoom: 6 },
+      }),
+    );
+  });
+
+  it("reports movement and clicks in neutral shapes", () => {
+    const onMoveEnd = jest.fn();
+    const onClick = jest.fn();
+    const click = new MouseEvent("click");
+    render(
+      <MapView styleUrl="style.json" onMoveEnd={onMoveEnd} onClick={onClick}>
+        {null}
+      </MapView>,
+    );
+
+    act(() => {
+      lastMapProps().onMoveEnd({ viewState: { longitude: 30, latitude: 40, zoom: 8 } });
+      lastMapProps().onClick({
+        lngLat: { lng: 1, lat: 2 },
+        point: { x: 3, y: 4 },
+        originalEvent: click,
+      });
+    });
+
+    expect(onMoveEnd).toHaveBeenCalledWith({ center: { lng: 30, lat: 40 }, zoom: 8 });
+    expect(onClick).toHaveBeenCalledWith({
+      type: "click",
+      at: { lng: 1, lat: 2 },
+      point: { x: 3, y: 4 },
+      originalEvent: click,
+    });
+  });
+});
+
+describe("useMap", () => {
+  const Probe = ({ report }: { report: (map: MapInstance | undefined) => void }) => {
+    report(useMap());
+    return null;
+  };
+
+  it("hands back the instance itself, stable across renders", () => {
+    currentEngineMap = engine;
+    const seen: Array<MapInstance | undefined> = [];
+    const view = render(<Probe report={(map) => seen.push(map)} />);
+    view.rerender(<Probe report={(map) => seen.push(map)} />);
+
+    expect(seen[0]).toBeDefined();
+    expect(seen[0]?.getZoom()).toBe(4);
+    expect(seen[1]).toBe(seen[0]);
+  });
+
+  it("is undefined until there is a map", () => {
+    const seen: Array<MapInstance | undefined> = [];
+    render(<Probe report={(map) => seen.push(map)} />);
+
+    expect(seen[0]).toBeUndefined();
+  });
+});
+
+describe("DataLayer", () => {
+  const points = [
+    { id: "a", at: { lng: 103.75, lat: 1.25 }, color: "rgb(1, 2, 3)", radius: 9 },
+    { id: "b", at: { lng: 151.21, lat: -33.86 } },
+  ];
+
+  it("draws points as a GeoJSON source and one data-driven circle layer", () => {
+    render(<MapView styleUrl="style.json">{<DataLayer id="photos" points={points} />}</MapView>);
+
+    expect(sourceProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "photos-points",
+        type: "geojson",
+        cluster: false,
+        data: {
+          type: "FeatureCollection",
+          features: [
+            {
+              type: "Feature",
+              id: "a",
+              properties: { id: "a", color: "rgb(1, 2, 3)", radius: 9 },
+              geometry: { type: "Point", coordinates: [103.75, 1.25] },
+            },
+            {
+              type: "Feature",
+              id: "b",
+              properties: { id: "b" },
+              geometry: { type: "Point", coordinates: [151.21, -33.86] },
+            },
+          ],
+        },
+      }),
+    );
+    expect(layerProps).toHaveBeenCalledTimes(1);
+    expect(layerProps).toHaveBeenCalledWith({
+      id: "photos-point-circles",
+      type: "circle",
+      paint: {
+        "circle-color": ["coalesce", ["get", "color"], "rgb(230, 32, 101)"],
+        "circle-radius": ["coalesce", ["get", "radius"], 5],
+      },
+    });
+  });
+
+  it("adds cluster and cluster-count layers when clustering is asked for", () => {
+    render(
+      <MapView styleUrl="style.json">{<DataLayer id="photos" points={points} cluster />}</MapView>,
+    );
+
+    expect(sourceProps).toHaveBeenCalledWith(
+      expect.objectContaining({ cluster: true, clusterMaxZoom: 12, clusterRadius: 42 }),
+    );
+    expect(screen.getAllByTestId("layer").map((node) => node.textContent)).toEqual([
+      "photos-clusters",
+      "photos-cluster-labels",
+      "photos-point-circles",
+    ]);
+    const [clusters, labels, circles] = layerProps.mock.calls.map(([props]) => props);
+    expect(clusters).toEqual(
+      expect.objectContaining({ type: "circle", filter: ["has", "point_count"] }),
+    );
+    expect(clusters.paint["circle-radius"][0]).toBe("step");
+    expect(labels).toEqual(
+      expect.objectContaining({
+        type: "symbol",
+        layout: expect.objectContaining({ "text-field": ["get", "point_count"] }),
+      }),
+    );
+    // Individual points must not be drawn twice: clustered ones belong to the
+    // cluster layer, so the circle layer only takes what is left.
+    expect(circles.filter).toEqual(["!", ["has", "point_count"]]);
+  });
+
+  it("draws lines as their own source and line layer", () => {
+    const lines = [
+      {
+        id: "guess",
+        path: [
+          { lng: 0, lat: 0 },
+          { lng: 10, lat: 20 },
+        ],
+        color: "rgb(9, 9, 9)",
+        width: 2,
+      },
+    ];
+    render(<MapView styleUrl="style.json">{<DataLayer id="round" lines={lines} />}</MapView>);
+
+    expect(sourceProps).toHaveBeenCalledTimes(1);
+    expect(sourceProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "round-lines",
+        type: "geojson",
+        data: {
+          type: "FeatureCollection",
+          features: [
+            {
+              type: "Feature",
+              id: "guess",
+              properties: { id: "guess", color: "rgb(9, 9, 9)", width: 2 },
+              geometry: {
+                type: "LineString",
+                coordinates: [
+                  [0, 0],
+                  [10, 20],
+                ],
+              },
+            },
+          ],
+        },
+      }),
+    );
+    expect(layerProps).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: "round-line-strokes",
+        type: "line",
+        paint: { "line-color": ["get", "color"], "line-width": ["get", "width"] },
+      }),
+    );
+  });
+
+  it("updates the source data in place when the points change", () => {
+    const view = render(
+      <MapView styleUrl="style.json">{<DataLayer id="photos" points={points} />}</MapView>,
+    );
+    const source = screen.getByTestId("source");
+
+    view.rerender(
+      <MapView styleUrl="style.json">
+        {<DataLayer id="photos" points={[{ id: "c", at: { lng: 5, lat: 6 } }]} />}
+      </MapView>,
+    );
+
+    // Same mounted source, same id: the adapter sees new data rather than a
+    // removed and re-added source.
+    expect(screen.getByTestId("source")).toBe(source);
+    const [previous, next] = sourceProps.mock.calls.map(([props]) => props);
+    expect(next.id).toBe(previous.id);
+    expect(next.data.features).toHaveLength(1);
+    expect(next.data.features[0].geometry.coordinates).toEqual([5, 6]);
+  });
+});

--- a/src/components/map/react.tsx
+++ b/src/components/map/react.tsx
@@ -1,0 +1,429 @@
+/**
+ * The neutral React map API — the only map module application components import.
+ *
+ * This file is the binding: it may talk to `./adapters/maplibre`, and it is the
+ * one place where neutral shapes are translated into (and out of) the adapter's
+ * vocabulary. It deliberately re-exports no provider types; everything crossing
+ * this boundary is declared in `./port`.
+ */
+import React from "react";
+import type { Feature, FeatureCollection, LineString, Point } from "geojson";
+import AdapterMap, {
+  Layer,
+  type LayerProps,
+  type MapRef,
+  Marker as AdapterMarker,
+  Popup as AdapterPopup,
+  Source,
+  useMap as useAdapterMap,
+} from "./adapters/maplibre";
+import type {
+  Bounds,
+  CameraView,
+  FitBoundsOptions,
+  FlyToOptions,
+  LineFeature,
+  LngLat,
+  MapEvent,
+  MapEventName,
+  MapInstance,
+  MapPointerEvent,
+  MarkerAnchor,
+  PointFeature,
+  ScreenPoint,
+} from "./port";
+
+/* -------------------------------------------------------------------------- */
+/* Engine translation                                                          */
+/* -------------------------------------------------------------------------- */
+
+/**
+ * The parts of the engine's own event objects this binding reads. Declared
+ * structurally so the translation does not have to name provider types: a real
+ * engine event satisfies these, and so does a test double.
+ */
+type EnginePointerEvent = {
+  lngLat: { lng: number; lat: number };
+  point: { x: number; y: number };
+  originalEvent: MouseEvent;
+};
+
+type EngineWheelEvent = { originalEvent: WheelEvent };
+
+const toLngLat = (position: { lng: number; lat: number }): LngLat => ({
+  lng: position.lng,
+  lat: position.lat,
+});
+
+const subscribe = (
+  map: MapRef,
+  event: MapEventName,
+  emit: (event: MapEvent) => void,
+): (() => void) => {
+  if (event === "click" || event === "contextmenu") {
+    const handler = (engineEvent: EnginePointerEvent) => {
+      emit({
+        type: event,
+        at: toLngLat(engineEvent.lngLat),
+        point: { x: engineEvent.point.x, y: engineEvent.point.y },
+        originalEvent: engineEvent.originalEvent,
+      });
+    };
+    map.on(event, handler);
+
+    return () => {
+      map.off(event, handler);
+    };
+  }
+
+  if (event === "wheel") {
+    const handler = (engineEvent: EngineWheelEvent) => {
+      emit({ type: "wheel", originalEvent: engineEvent.originalEvent });
+    };
+    map.on("wheel", handler);
+
+    return () => {
+      map.off("wheel", handler);
+    };
+  }
+
+  // Camera events carry no payload of their own: the map is the source of truth.
+  const handler = () => {
+    emit({ type: event, view: { center: toLngLat(map.getCenter()), zoom: map.getZoom() } });
+  };
+  map.on(event, handler);
+
+  return () => {
+    map.off(event, handler);
+  };
+};
+
+const createMapInstance = (map: MapRef): MapInstance => ({
+  getCenter: (): LngLat => toLngLat(map.getCenter()),
+  getZoom: (): number => map.getZoom(),
+  getBounds: (): Bounds => {
+    const bounds = map.getBounds();
+
+    return [
+      { lng: bounds.getWest(), lat: bounds.getSouth() },
+      { lng: bounds.getEast(), lat: bounds.getNorth() },
+    ];
+  },
+  flyTo: (options: FlyToOptions): void => {
+    map.flyTo({
+      center: [options.center.lng, options.center.lat],
+      ...(options.zoom !== undefined ? { zoom: options.zoom } : {}),
+      ...(options.speed !== undefined ? { speed: options.speed } : {}),
+    });
+  },
+  fitBounds: (bounds: Bounds, options?: FitBoundsOptions): void => {
+    const [southWest, northEast] = bounds;
+    map.fitBounds(
+      [
+        [southWest.lng, southWest.lat],
+        [northEast.lng, northEast.lat],
+      ],
+      {
+        ...(options?.padding !== undefined ? { padding: options.padding } : {}),
+        ...(options?.maxZoom !== undefined ? { maxZoom: options.maxZoom } : {}),
+        ...(options?.animate !== undefined ? { animate: options.animate } : {}),
+      },
+    );
+  },
+  project: (at: LngLat): ScreenPoint => {
+    const point = map.project([at.lng, at.lat]);
+
+    return { x: point.x, y: point.y };
+  },
+  unproject: (at: ScreenPoint): LngLat => toLngLat(map.unproject([at.x, at.y])),
+  on: (event, listener) => subscribe(map, event, listener as (value: MapEvent) => void),
+  getContainer: (): HTMLElement => map.getContainer(),
+});
+
+/**
+ * One neutral handle per underlying map, so `useMap()` is referentially stable
+ * across renders and the handle a consumer stores in an effect dependency list
+ * does not churn.
+ */
+const instances = new WeakMap<MapRef, MapInstance>();
+
+const toMapInstance = (map: MapRef): MapInstance => {
+  const existing = instances.get(map);
+  if (existing) {
+    return existing;
+  }
+
+  const instance = createMapInstance(map);
+  instances.set(map, instance);
+
+  return instance;
+};
+
+/* -------------------------------------------------------------------------- */
+/* Components                                                                  */
+/* -------------------------------------------------------------------------- */
+
+export type MapViewProps = {
+  /** A style document URL the provider can load. */
+  styleUrl: string;
+  /** Read once, at construction — the camera is uncontrolled after that. */
+  initialView?: { center?: LngLat; zoom?: number };
+  onLoad?: (map: MapInstance) => void;
+  onMoveEnd?: (view: CameraView) => void;
+  onClick?: (event: MapPointerEvent) => void;
+  onContextMenu?: (event: MapPointerEvent) => void;
+  children?: React.ReactNode;
+  className?: string;
+  style?: React.CSSProperties;
+};
+
+export const MapView = ({
+  styleUrl,
+  initialView,
+  onLoad,
+  onMoveEnd,
+  onClick,
+  onContextMenu,
+  children,
+  className,
+  style,
+}: MapViewProps): React.JSX.Element => {
+  const center = initialView?.center;
+  const zoom = initialView?.zoom;
+
+  return (
+    <AdapterMap
+      mapStyle={styleUrl}
+      initialViewState={{
+        ...(center ? { longitude: center.lng, latitude: center.lat } : {}),
+        ...(zoom !== undefined ? { zoom } : {}),
+      }}
+      {...(className !== undefined ? { className } : {})}
+      {...(style !== undefined ? { style } : {})}
+      onLoad={(event) => {
+        onLoad?.(toMapInstance(event.target));
+      }}
+      onMoveEnd={(event) => {
+        onMoveEnd?.({
+          center: { lng: event.viewState.longitude, lat: event.viewState.latitude },
+          zoom: event.viewState.zoom,
+        });
+      }}
+      onClick={(event) => {
+        onClick?.({
+          type: "click",
+          at: toLngLat(event.lngLat),
+          point: { x: event.point.x, y: event.point.y },
+          originalEvent: event.originalEvent,
+        });
+      }}
+      onContextMenu={(event) => {
+        onContextMenu?.({
+          type: "contextmenu",
+          at: toLngLat(event.lngLat),
+          point: { x: event.point.x, y: event.point.y },
+          originalEvent: event.originalEvent,
+        });
+      }}
+    >
+      {children}
+    </AdapterMap>
+  );
+};
+
+/**
+ * The live map, or `undefined` before it has loaded and outside a `<MapView>`.
+ * Unlike the adapter's hook this returns the instance itself, not a holder.
+ */
+export const useMap = (): MapInstance | undefined => {
+  const { current } = useAdapterMap();
+
+  return React.useMemo(() => (current ? toMapInstance(current) : undefined), [current]);
+};
+
+export type MarkerProps = {
+  at: LngLat;
+  anchor?: MarkerAnchor;
+  children: React.ReactNode;
+};
+
+/**
+ * A single DOM marker — for the small, rich case (a photo thumbnail, a pin with
+ * its own interactions). Bulk data belongs in `<DataLayer>`.
+ */
+export const Marker = ({ at, anchor, children }: MarkerProps): React.JSX.Element => (
+  <AdapterMarker longitude={at.lng} latitude={at.lat} {...(anchor !== undefined ? { anchor } : {})}>
+    {children}
+  </AdapterMarker>
+);
+
+export type PopupProps = {
+  at: LngLat;
+  children: React.ReactNode;
+};
+
+export const Popup = ({ at, children }: PopupProps): React.JSX.Element => (
+  <AdapterPopup longitude={at.lng} latitude={at.lat}>
+    {children}
+  </AdapterPopup>
+);
+
+/* -------------------------------------------------------------------------- */
+/* DataLayer                                                                   */
+/* -------------------------------------------------------------------------- */
+
+/** Used when a point does not carry its own colour. */
+const DEFAULT_POINT_COLOUR = "rgb(230, 32, 101)";
+/** Used when a point does not carry its own radius, in pixels. */
+const DEFAULT_POINT_RADIUS = 5;
+const CLUSTER_MAX_ZOOM = 12;
+const CLUSTER_RADIUS = 42;
+
+type PointProperties = { id: string; color?: string; radius?: number };
+type LineProperties = { id: string; color: string; width: number };
+
+const toPointCollection = (
+  points: readonly PointFeature[],
+): FeatureCollection<Point, PointProperties> => ({
+  type: "FeatureCollection",
+  features: points.map(
+    (point): Feature<Point, PointProperties> => ({
+      type: "Feature",
+      id: point.id,
+      properties: {
+        id: point.id,
+        ...(point.color !== undefined ? { color: point.color } : {}),
+        ...(point.radius !== undefined ? { radius: point.radius } : {}),
+      },
+      geometry: { type: "Point", coordinates: [point.at.lng, point.at.lat] },
+    }),
+  ),
+});
+
+const toLineCollection = (
+  lines: readonly LineFeature[],
+): FeatureCollection<LineString, LineProperties> => ({
+  type: "FeatureCollection",
+  features: lines.map(
+    (line): Feature<LineString, LineProperties> => ({
+      type: "Feature",
+      id: line.id,
+      properties: { id: line.id, color: line.color, width: line.width },
+      geometry: {
+        type: "LineString",
+        coordinates: line.path.map((at) => [at.lng, at.lat]),
+      },
+    }),
+  ),
+});
+
+/**
+ * Colour and radius are read off each feature so one layer can draw a whole set
+ * of differently styled points — that is what keeps bulk data on the GPU.
+ */
+const circleLayer = (id: string, clustered: boolean): LayerProps =>
+  clustered
+    ? {
+        id: `${id}-point-circles`,
+        type: "circle",
+        filter: ["!", ["has", "point_count"]],
+        paint: {
+          "circle-color": ["coalesce", ["get", "color"], DEFAULT_POINT_COLOUR],
+          "circle-radius": ["coalesce", ["get", "radius"], DEFAULT_POINT_RADIUS],
+        },
+      }
+    : {
+        id: `${id}-point-circles`,
+        type: "circle",
+        paint: {
+          "circle-color": ["coalesce", ["get", "color"], DEFAULT_POINT_COLOUR],
+          "circle-radius": ["coalesce", ["get", "radius"], DEFAULT_POINT_RADIUS],
+        },
+      };
+
+const clusterLayer = (id: string): LayerProps => ({
+  id: `${id}-clusters`,
+  type: "circle",
+  filter: ["has", "point_count"],
+  paint: {
+    "circle-color": DEFAULT_POINT_COLOUR,
+    "circle-stroke-color": "rgba(255, 255, 255, 0.78)",
+    "circle-stroke-width": 2,
+    "circle-radius": ["step", ["get", "point_count"], 13, 10, 18, 30, 24, 80, 31],
+    "circle-blur": 0.08,
+  },
+});
+
+const clusterLabelLayer = (id: string): LayerProps => ({
+  id: `${id}-cluster-labels`,
+  type: "symbol",
+  filter: ["has", "point_count"],
+  layout: {
+    "text-field": ["get", "point_count"],
+    "text-size": 12,
+    "text-font": ["Noto Sans Bold"],
+  },
+  paint: {
+    "text-color": "rgba(0, 0, 0, 0.9)",
+    "text-halo-color": "rgba(255, 255, 255, 0.96)",
+    "text-halo-width": 1.2,
+    "text-halo-blur": 0.4,
+  },
+});
+
+const lineLayer = (id: string): LayerProps => ({
+  id: `${id}-line-strokes`,
+  type: "line",
+  layout: { "line-cap": "round", "line-join": "round" },
+  paint: {
+    "line-color": ["get", "color"],
+    "line-width": ["get", "width"],
+  },
+});
+
+export type DataLayerProps = {
+  /** Prefixes the source and layer ids this layer owns. */
+  id: string;
+  points?: readonly PointFeature[];
+  lines?: readonly LineFeature[];
+  /** Groups nearby points into counted clusters at low zoom. */
+  cluster?: boolean;
+};
+
+/**
+ * Bulk data drawn by the provider rather than by React — one GPU pass for the
+ * whole set, instead of a DOM node per feature. Callers describe features; the
+ * style-spec that renders them never leaves this module.
+ */
+export const DataLayer = ({
+  id,
+  points,
+  lines,
+  cluster = false,
+}: DataLayerProps): React.JSX.Element => {
+  const pointData = React.useMemo(() => (points ? toPointCollection(points) : null), [points]);
+  const lineData = React.useMemo(() => (lines ? toLineCollection(lines) : null), [lines]);
+
+  return (
+    <>
+      {pointData ? (
+        <Source
+          id={`${id}-points`}
+          type="geojson"
+          data={pointData}
+          cluster={cluster}
+          {...(cluster ? { clusterMaxZoom: CLUSTER_MAX_ZOOM, clusterRadius: CLUSTER_RADIUS } : {})}
+        >
+          {cluster ? <Layer {...clusterLayer(id)} /> : null}
+          {cluster ? <Layer {...clusterLabelLayer(id)} /> : null}
+          <Layer {...circleLayer(id, cluster)} />
+        </Source>
+      ) : null}
+      {lineData ? (
+        <Source id={`${id}-lines`} type="geojson" data={lineData}>
+          <Layer {...lineLayer(id)} />
+        </Source>
+      ) : null}
+    </>
+  );
+};

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -39,7 +39,6 @@
         "react": "^19.2.7",
         "react-colorful": "^5.8.0",
         "react-dom": "^19.2.7",
-        "react-map-gl": "^8.1.1",
         "sharp": "^0.35.3",
         "sqlite3": "^6.0.1",
         "use-debounce": "^10.1.1",
@@ -5427,66 +5426,6 @@
         }
       }
     },
-    "node_modules/@vis.gl/react-mapbox": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@vis.gl/react-mapbox/-/react-mapbox-8.1.1.tgz",
-      "integrity": "sha512-KMDTjtWESXxHS4uqWxjsvgQUHvuL3Z6SdKe68o7Nxma2qUfuyH3x4TCkIqGn3FQTrFvZLWvTnSAbGvtm+Kd13A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "mapbox-gl": ">=3.5.0",
-        "react": ">=16.3.0",
-        "react-dom": ">=16.3.0"
-      },
-      "peerDependenciesMeta": {
-        "mapbox-gl": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vis.gl/react-maplibre": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/@vis.gl/react-maplibre/-/react-maplibre-8.1.1.tgz",
-      "integrity": "sha512-iUOfzJAhFAJwEZp1644tQb7LOTFgi5/GzdaztkhzNgFVuoF2Ez7guvwZjQAKB9CN2TlHTgNuYH8UW85kO7cVhw==",
-      "license": "MIT",
-      "dependencies": {
-        "@maplibre/maplibre-gl-style-spec": "^19.2.1"
-      },
-      "peerDependencies": {
-        "maplibre-gl": ">=4.0.0",
-        "react": ">=16.3.0",
-        "react-dom": ">=16.3.0"
-      },
-      "peerDependenciesMeta": {
-        "maplibre-gl": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@vis.gl/react-maplibre/node_modules/@maplibre/maplibre-gl-style-spec": {
-      "version": "19.3.3",
-      "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-19.3.3.tgz",
-      "integrity": "sha512-cOZZOVhDSulgK0meTsTkmNXb1ahVvmTmWmfx9gRBwc6hq98wS9JP35ESIoNq3xqEan+UN+gn8187Z6E4NKhLsw==",
-      "license": "ISC",
-      "dependencies": {
-        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
-        "@mapbox/unitbezier": "^0.0.1",
-        "json-stringify-pretty-compact": "^3.0.0",
-        "minimist": "^1.2.8",
-        "rw": "^1.3.3",
-        "sort-object": "^3.0.3"
-      },
-      "bin": {
-        "gl-style-format": "dist/gl-style-format.mjs",
-        "gl-style-migrate": "dist/gl-style-migrate.mjs",
-        "gl-style-validate": "dist/gl-style-validate.mjs"
-      }
-    },
-    "node_modules/@vis.gl/react-maplibre/node_modules/json-stringify-pretty-compact": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-3.0.0.tgz",
-      "integrity": "sha512-Rc2suX5meI0S3bfdZuA7JMFBGkJ875ApfVyq2WHELjBiiG22My/l7/8zPpH/CfFVQHuVLd8NLR0nv6vi0BYYKA==",
-      "license": "MIT"
-    },
     "node_modules/abbrev": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-4.0.0.tgz",
@@ -5601,24 +5540,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "dequal": "^2.0.3"
-      }
-    },
-    "node_modules/arr-union": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/assign-symbols": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/babel-jest": {
@@ -5869,25 +5790,6 @@
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
       "license": "MIT"
-    },
-    "node_modules/bytewise": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/bytewise/-/bytewise-1.1.0.tgz",
-      "integrity": "sha512-rHuuseJ9iQ0na6UDhnrRVDh8YnWVlU6xM3VH6q/+yHDeUH2zIhUzP+2/h3LIrhLDBtTqzWpE3p3tP/boefskKQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bytewise-core": "^1.2.2",
-        "typewise": "^1.0.3"
-      }
-    },
-    "node_modules/bytewise-core": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/bytewise-core/-/bytewise-core-1.2.3.tgz",
-      "integrity": "sha512-nZD//kc78OOxeYtRlVk8/zXqTB4gf/nlguL1ggWA8FuchMyOxcyHR4QPQZMUmA7czC+YnaBrPUCubqAWe50DaA==",
-      "license": "MIT",
-      "dependencies": {
-        "typewise-core": "^1.2"
-      }
     },
     "node_modules/cacache": {
       "version": "20.0.4",
@@ -6805,18 +6707,6 @@
       "license": "Apache-2.0",
       "optional": true
     },
-    "node_modules/extend-shallow": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
-      "license": "MIT",
-      "dependencies": {
-        "is-extendable": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
@@ -7033,15 +6923,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/get-value": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/github-from-package": {
@@ -7399,15 +7280,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/is-extendable": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
-      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -7426,18 +7298,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/is-plain-object": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-      "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-      "license": "MIT",
-      "dependencies": {
-        "isobject": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -7477,15 +7337,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
-    },
-    "node_modules/isobject": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-      "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.2",
@@ -10678,30 +10529,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/react-map-gl": {
-      "version": "8.1.1",
-      "resolved": "https://registry.npmjs.org/react-map-gl/-/react-map-gl-8.1.1.tgz",
-      "integrity": "sha512-aSqFAFoxvY7wxbGI93Dz0E41171mkAb3GcNbnkFIotmu88OFw495os6mIDZSi7irYNT/PZEIOEHUxhun4ToGuQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@vis.gl/react-mapbox": "8.1.1",
-        "@vis.gl/react-maplibre": "8.1.1"
-      },
-      "peerDependencies": {
-        "mapbox-gl": ">=1.13.0",
-        "maplibre-gl": ">=1.13.0",
-        "react": ">=16.3.0",
-        "react-dom": ">=16.3.0"
-      },
-      "peerDependenciesMeta": {
-        "mapbox-gl": {
-          "optional": true
-        },
-        "maplibre-gl": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/react-virtualized-auto-sizer": {
       "version": "1.0.26",
       "resolved": "https://registry.npmjs.org/react-virtualized-auto-sizer/-/react-virtualized-auto-sizer-1.0.26.tgz",
@@ -10816,12 +10643,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/rw": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
-      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
@@ -10910,21 +10731,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/set-value": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
-      "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^2.0.1",
-        "is-extendable": "^0.1.1",
-        "is-plain-object": "^2.0.3",
-        "split-string": "^3.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/sharp": {
@@ -11116,41 +10922,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/sort-asc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.2.0.tgz",
-      "integrity": "sha512-umMGhjPeHAI6YjABoSTrFp2zaBtXBej1a0yKkuMUyjjqu6FJsTF+JYwCswWDg+zJfk/5npWUUbd33HH/WLzpaA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sort-desc": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.2.0.tgz",
-      "integrity": "sha512-NqZqyvL4VPW+RAxxXnB8gvE1kyikh8+pR+T+CXLksVRN9eiQqkQlPwqWYU0mF9Jm7UnctShlxLyAt1CaBOTL1w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sort-object": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-3.0.3.tgz",
-      "integrity": "sha512-nK7WOY8jik6zaG9CRwZTaD5O7ETWDLZYMM12pqY8htll+7dYeqGfEUPcUBHOpSJg2vJOrvFIY2Dl5cX2ih1hAQ==",
-      "license": "MIT",
-      "dependencies": {
-        "bytewise": "^1.1.0",
-        "get-value": "^2.0.2",
-        "is-extendable": "^0.1.1",
-        "sort-asc": "^0.2.0",
-        "sort-desc": "^0.2.0",
-        "union-value": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -11179,43 +10950,6 @@
       "dependencies": {
         "buffer-from": "^1.0.0",
         "source-map": "^0.6.0"
-      }
-    },
-    "node_modules/split-string": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-      "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-      "license": "MIT",
-      "dependencies": {
-        "extend-shallow": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/split-string/node_modules/extend-shallow": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-      "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
-      "license": "MIT",
-      "dependencies": {
-        "assign-symbols": "^1.0.0",
-        "is-extendable": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/split-string/node_modules/is-extendable": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-      "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-      "license": "MIT",
-      "dependencies": {
-        "is-plain-object": "^2.0.4"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/sprintf-js": {
@@ -11806,41 +11540,11 @@
         "tsc6": "bin/tsc6"
       }
     },
-    "node_modules/typewise": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/typewise/-/typewise-1.0.3.tgz",
-      "integrity": "sha512-aXofE06xGhaQSPzt8hlTY+/YWQhm9P0jYUp1f2XtmW/3Bk0qzXcyFWAtPoo2uTGQj1ZwbDuSyuxicq+aDo8lCQ==",
-      "license": "MIT",
-      "dependencies": {
-        "typewise-core": "^1.2.0"
-      }
-    },
-    "node_modules/typewise-core": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/typewise-core/-/typewise-core-1.2.0.tgz",
-      "integrity": "sha512-2SCC/WLzj2SbUwzFOzqMCkz5amXLlxtJqDKTICqg30x+2DZxcfZN2MvQZmGfXWKNWaKK9pBPsvkcwv8bF/gxKg==",
-      "license": "MIT"
-    },
     "node_modules/undici-types": {
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
       "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "license": "MIT"
-    },
-    "node_modules/union-value": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
-      "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
-      "license": "MIT",
-      "dependencies": {
-        "arr-union": "^3.1.0",
-        "get-value": "^2.0.6",
-        "is-extendable": "^0.1.1",
-        "set-value": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
     },
     "node_modules/unrs-resolver": {
       "version": "1.11.1",

--- a/src/package.json
+++ b/src/package.json
@@ -72,7 +72,6 @@
     "react": "^19.2.7",
     "react-colorful": "^5.8.0",
     "react-dom": "^19.2.7",
-    "react-map-gl": "^8.1.1",
     "sharp": "^0.35.3",
     "sqlite3": "^6.0.1",
     "use-debounce": "^10.1.1",


### PR DESCRIPTION
Phases 1 and 2 (scaffolding) of `docs/plan-003-map-abstraction.md`.

## Phase 1 — react-map-gl removed
`src/components/map/adapters/maplibre/` is a drop-in for the exact surface this repo used (default `Map`, `Marker`, `Popup`, `Source`, `Layer`, `useMap`, the four controls, event types). All ten map components import it; `react-map-gl` is uninstalled.

Camera events are **synthesised** from `getCenter`/`getZoom`/`getBearing`/`getPitch` rather than read off event payloads — which is exactly what broke react-map-gl 8.1.1 under MapLibre 6, so this is what makes that upgrade tractable.

## Phase 2 — neutral port (scaffolding only)
- `port.ts` — pure types, zero imports (no React, no maplibre)
- `react.tsx` — `MapView` / `useMap` / `Marker` / `Popup` / `DataLayer` over the adapter
- `DataLayer` turns neutral point/line features into a GeoJSON source + data-driven circle/line layers, reusing `StatsWorldMap`'s existing cluster defaults so the consumer migration should be visually neutral

No consumer uses the port yet — that's the next PR.

## Verification
- tsc 0 across all configs, lint green, 1830 unit tests
- Full Playwright chromium suite: the entire map suite passes (world/guess/stats maps, route overlay, markers, context menu, map-time-range)
- One local e2e failure in `hydration.spec.ts › /search hydrates…` — `/search` imports **no** map code, it passed in CI on main at 9.5s against a 15s timeout, and it reproduces locally even on an idle machine. Pushing to let CI adjudicate in a clean environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)